### PR TITLE
Fix observeAttribute non-function cleanup error

### DIFF
--- a/lib/observeAttribute.lua
+++ b/lib/observeAttribute.lua
@@ -22,6 +22,8 @@ local function defaultGuard(_value: AttributeValue)
 end
 
 --[=[
+	@within Observers
+
 	Creates an observer around an attribute of a given instance. The callback will fire for any non-nil
 	attribute value.
 

--- a/lib/observeAttribute.lua
+++ b/lib/observeAttribute.lua
@@ -22,8 +22,6 @@ local function defaultGuard(_value: AttributeValue)
 end
 
 --[=[
-	@within Observers
-
 	Creates an observer around an attribute of a given instance. The callback will fire for any non-nil
 	attribute value.
 
@@ -85,11 +83,13 @@ local function observeAttribute(
 		if value ~= nil and valueGuard(value) then
 			task.spawn(function()
 				local clean = callback(value)
-				if id == changedId and onAttrChangedConn.Connected then
-					cleanFn = clean
-				else
-					task.spawn(clean)
-				end
+				if typeof(clean) == "function" then
+					if id == changedId and onAttrChangedConn.Connected then
+						cleanFn = clean
+					else
+						task.spawn(clean)
+					end
+				end;
 			end)
 		end
 	end


### PR DESCRIPTION
![image](https://github.com/Sleitnick/RbxObservers/assets/70824139/cba82c06-fbbb-437f-897d-c5ecafff184e)

I received this error in my fork of RbxObservers and this pull request fixes it by checking if the return of callback is a function or not. This is the same check as the other observers in this library perform.