### PR TITLE
Support new PlayerExitReason for PlayerRemoving

### DIFF
--- a/lib/observePlayer.luau
+++ b/lib/observePlayer.luau
@@ -27,6 +27,7 @@ local function observePlayer(callback: Callback): () -> ()
 	local playerRemovingConn: RBXScriptConnection
 
 	local cleanupsPerPlayer: { [Player]: (exitReason: Enum.PlayerExitReason) -> () } = {}
+	local inflight: { [Player]: Enum.PlayerExitReason } = {}
 
 	local function OnPlayerAdded(player: Player)
 		if not playerAddedConn.Connected then
@@ -34,18 +35,24 @@ local function observePlayer(callback: Callback): () -> ()
 		end
 
 		task.spawn(function()
+			inflight[player] = Enum.PlayerExitReason.Unknown
 			local cleanup = (callback :: any)(player)
 			if typeof(cleanup) == "function" then
 				if playerAddedConn.Connected and player.Parent then
 					cleanupsPerPlayer[player] = cleanup
 				else
-					task.spawn(cleanup, Enum.PlayerExitReason.Unknown)
+					task.spawn(cleanup, inflight[player])
 				end
 			end
+			inflight[player] = nil
 		end)
 	end
 
 	local function OnPlayerRemoving(player: Player, exitReason: Enum.PlayerExitReason)
+		if inflight[player] then
+			inflight[player] = exitReason
+		end
+		
 		local cleanup = cleanupsPerPlayer[player]
 		cleanupsPerPlayer[player] = nil
 		if typeof(cleanup) == "function" then
@@ -75,7 +82,7 @@ local function observePlayer(callback: Callback): () -> ()
 
 		local player = next(cleanupsPerPlayer)
 		while player do
-			OnPlayerRemoving(player, Enum.PlayerExitReason.Unknown)
+			OnPlayerRemoving(player, inflight[player])
 			player = next(cleanupsPerPlayer)
 		end
 	end


### PR DESCRIPTION
Pass the PlayerExitReason enum from PlayerRemoving to the cleanup function

https://devforum.roblox.com/t/new-exitreason-parameter-for-playerremoving/4029827